### PR TITLE
Add rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,153 @@
+AllCops:
+  NewCops: enable
+  SuggestExtensions: false
+  TargetRubyVersion: 3.1
+
+#
+# our rules
+#
+
+Layout/FirstArrayElementIndentation: { Exclude: ['spec/**/*'] }
+Layout/LineLength: { Enabled: false }
+Layout/SpaceAroundEqualsInParameterDefault: { EnforcedStyle: no_space }
+Lint/ConstantDefinitionInBlock: { Exclude: ['spec/**/*'] }
+Metrics: { Enabled: false }
+Style/SymbolArray: { EnforcedStyle: brackets }
+Style/IfInsideElse: { Enabled: false } # Offense count: 1
+Style/PercentLiteralDelimiters:
+  Enabled: true
+  PreferredDelimiters:
+    default: '{}'
+    '%i': '[]'
+    '%I': '[]'
+    '%w': '[]'
+    '%W': '[]'
+Style/UnlessElse: { Enabled: false }
+Bundler/OrderedGems: { Enabled: false }
+Style/CaseEquality: { Exclude: ['lib/ronin/web/server/conditions.rb'] }
+Style/Next: { Enabled: false }
+Style/HashSyntax: { Enabled: false }
+Naming/BlockForwarding: { Enabled: false }
+Lint/ReturnInVoidContext: { Enabled: false }
+Gemspec/DeprecatedAttributeAssignment: { Enabled: false }
+
+#
+# rules that are in flux
+#
+
+# consider enabling these and autocorrecting?
+# Layout/SpaceAfterComma
+# Layout/SpaceAroundKeyword
+# Layout/SpaceBeforeComma
+# Layout/SpaceInsideHashLiteralBraces
+# Layout/SpaceInsideParens
+# Layout/TrailingWhitespace
+# Lint/UnreachableLoop
+# Lint/UnusedBlockArgument
+# Style/ClassCheck
+# Style/Documentation
+# Style/ExpandPathArguments
+# Style/GlobalStdStream
+# Style/HashSyntax
+# Style/KeywordParametersOrder
+# Style/MethodCallWithoutArgsParentheses
+# Style/MutableConstant
+# Style/QuotedSymbols: { EnforcedStyle: double_quotes }
+# Style/RedundantReturn
+# Style/SafeNavigation
+# Style/SpecialGlobalVars
+# Style/StringLiterals: { EnforcedStyle: double_quotes }
+# Style/WordArray
+
+# these have been fixed
+# Gemspec/DuplicatedAssignment: { Enabled: false } # Offense count: 1
+# Layout/ElseAlignment: { Enabled: false } # Offense count: 1
+# Layout/EndAlignment: { Enabled: false } # Offense count: 1
+# Lint/DuplicateMethods: { Enabled: false } # Offense count: 1
+# Lint/UselessAssignment: { Enabled: false } # Offense count: 1
+# Style/Encoding: { Enabled: false } # Offense count: 2
+# Style/RedundantBegin: { Enabled: false } # Offense count: 2
+# Style/RedundantInterpolation: { Enabled: false } # Offense count: 1
+# Style/TrailingCommaInArrayLiteral: { Enabled: false } # Offense count: 1
+
+#
+# This list was generated with:
+# bundle exec rubocop --auto-gen-config --exclude-limit 1
+#
+
+# > 10 violations
+Layout/AssignmentIndentation: { Enabled: false } # Offense count: 11
+Layout/EmptyLinesAroundClassBody: { Enabled: false } # Offense count: 76
+Layout/HashAlignment: { Enabled: false } # Offense count: 28
+Layout/SpaceAfterComma: { Enabled: false } # Offense count: 141
+Layout/SpaceInsideHashLiteralBraces: { Enabled: false } # Offense count: 57
+Layout/TrailingWhitespace: { Enabled: false } # Offense count: 50
+Naming/RescuedExceptionsVariableName: { Enabled: false } # Offense count: 11
+Style/BlockDelimiters: { Enabled: false } # Offense count: 17
+Style/ClassCheck: { Enabled: false } # Offense count: 10
+Style/ClassEqualityComparison: { Enabled: false } # Offense count: 16
+Style/FrozenStringLiteralComment: { Enabled: false } # Offense count: 77
+Style/GlobalStdStream: { Enabled: false } # Offense count: 13
+Style/GuardClause: { Enabled: false } # Offense count: 10
+Style/IfUnlessModifier: { Enabled: false } # Offense count: 13
+Style/MethodCallWithoutArgsParentheses: { Enabled: false } # Offense count: 10
+Style/SpecialGlobalVars: { Enabled: false } # Offense count: 28
+Style/StringLiterals: { Enabled: false } # Offense count: 774
+Lint/ElseLayout: { Enabled: false } # Offense count: 22
+
+# < 10 violations
+Layout/EmptyLinesAroundModuleBody: { Enabled: false } # Offense count: 5
+Layout/ExtraSpacing: { Enabled: false } # Offense count: 6
+Layout/FirstHashElementIndentation: { Enabled: false } # Offense count: 4
+Layout/ParameterAlignment: { Enabled: false } # Offense count: 9
+Layout/SpaceAroundKeyword: { Enabled: false } # Offense count: 7
+Layout/SpaceBeforeComma: { Enabled: false } # Offense count: 4
+Layout/SpaceInsideParens: { Enabled: false } # Offense count: 4
+Lint/EmptyClass: { Enabled: false } # Offense count: 3
+Lint/SuppressedException: { Enabled: false } # Offense count: 4
+Lint/UnusedMethodArgument: { Enabled: false } # Offense count: 5
+Style/AccessorGrouping: { Enabled: false } # Offense count: 7
+Style/Documentation: { Enabled: false } # Offense count: 3
+Style/ExpandPathArguments: { Enabled: false } # Offense count: 8
+Style/KeywordParametersOrder: { Enabled: false } # Offense count: 8
+Style/Lambda: { Enabled: false } # Offense count: 3
+Style/MutableConstant: { Enabled: false } # Offense count: 4
+Style/RaiseArgs: { Enabled: false } # Offense count: 4
+Style/RedundantReturn: { Enabled: false } # Offense count: 7
+Style/SafeNavigation: { Enabled: false } # Offense count: 5
+Style/StringConcatenation: { Enabled: false } # Offense count: 8
+Style/WordArray: { Enabled: false } # Offense count: 4
+
+# 1 or 2 violations
+Layout/ArgumentAlignment: { Enabled: false } # Offense count: 1
+Layout/BlockAlignment: { Enabled: false } # Offense count: 1
+Layout/IndentationWidth: { Enabled: false } # Offense count: 2
+Layout/SpaceAroundOperators: { Enabled: false } # Offense count: 1
+Layout/SpaceBeforeBlockBraces: { Enabled: false } # Offense count: 1
+Lint/MissingSuper: { Enabled: false } # Offense count: 2
+Lint/RescueException: { Enabled: false } # Offense count: 1
+Lint/UnreachableLoop: { Enabled: false } # Offense count: 1
+Lint/UnusedBlockArgument: { Enabled: false } # Offense count: 1
+Naming/MethodParameterName: { Enabled: false } # Offense count: 1
+Style/EmptyMethod: { Enabled: false } # Offense count: 2
+Style/HashConversion: { Enabled: false } # Offense count: 1
+Style/MultilineMemoization: { Enabled: false } # Offense count: 1
+Style/NumericPredicate: { Enabled: false } # Offense count: 1
+Style/OptionalArguments: { Enabled: false } # Offense count: 1
+Style/ParenthesesAroundCondition: { Enabled: false } # Offense count: 1
+Style/PreferredHashMethods: { Enabled: false } # Offense count: 1
+Style/QuotedSymbols: { Enabled: false } # Offense count: 1
+Style/RedundantException: { Enabled: false } # Offense count: 1
+Style/RedundantRegexpEscape: { Enabled: false } # Offense count: 1
+Style/RegexpLiteral: { Enabled: false } # Offense count: 1
+Style/RescueStandardError: { Enabled: false } # Offense count: 1
+Style/SoleNestedConditional: { Enabled: false } # Offense count: 1
+Style/TrailingCommaInHashLiteral: { Enabled: false } # Offense count: 2
+
+# rubocop cannot tell that rubygems_mfa_required is enabled in gemspec.yml
+Gemspec/RequireMFA: { Enabled: false }
+
+# make an exception for our gemspec code
+Gemspec/DuplicatedAssignment:
+  Exclude:
+    - 'ronin-web-server.gemspec'

--- a/Gemfile
+++ b/Gemfile
@@ -27,4 +27,6 @@ group :development do
   gem 'yard-spellcheck', require: false
 
   gem 'dead_end', require: false
+
+  gem 'rubocop',  require: false
 end

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ begin
 rescue LoadError => e
   warn e.message
   warn "Run `gem install bundler` to install Bundler"
-  exit -1
+  exit(-1)
 end
 
 begin

--- a/lib/ronin/web/server/base.rb
+++ b/lib/ronin/web/server/base.rb
@@ -167,6 +167,7 @@ module Ronin
           handler      = detect_rack_handler
           handler_name = handler.name.gsub(/.*::/, '')
 
+          # rubocop:disable Lint/ShadowingOuterLocalVariable
           runner = lambda { |handler,server|
             begin
               handler.run(server,Host: bind, Port: port) do |server|
@@ -175,10 +176,11 @@ module Ronin
 
                 set :running, true
               end
-            rescue Errno::EADDRINUSE => e
-              $stderr.puts "ronin-web-server: address is already in use: #{bind}:#{port}"
+            rescue Errno::EADDRINUSE
+              warn "ronin-web-server: address is already in use: #{bind}:#{port}"
             end
           }
+          # rubocop:enable Lint/ShadowingOuterLocalVariable
 
           if options[:background]
             Thread.new(handler,self,&runner)

--- a/lib/ronin/web/server/conditions.rb
+++ b/lib/ronin/web/server/conditions.rb
@@ -166,7 +166,7 @@ module Ronin
           def referer(matcher)
             condition do
               if (referer = request.referer)
-                matcher === request.referer
+                matcher === referer
               end
             end
           end
@@ -381,7 +381,7 @@ module Ronin
             when :windows
               condition do
                 if (os = request.os)
-                  request.os.start_with?('Windows')
+                  os.start_with?('Windows')
                 end
               end
             else

--- a/lib/ronin/web/server/reverse_proxy/request.rb
+++ b/lib/ronin/web/server/reverse_proxy/request.rb
@@ -207,20 +207,20 @@ module Ronin
 
           alias referrer= referer=
 
-            #
-            # Changes the body of the request.
-            #
-            # @param [String] new_body
-            #   The new body for the request.
-            #
-            # @return [String]
-            #   The new body of the request.
-            #
-            # @api public
-            #
-            def body=(new_body)
-              @env['rack.input'] = new_body
-            end
+          #
+          # Changes the body of the request.
+          #
+          # @param [String] new_body
+          #   The new body for the request.
+          #
+          # @return [String]
+          #   The new body of the request.
+          #
+          # @api public
+          #
+          def body=(new_body)
+            @env['rack.input'] = new_body
+          end
 
         end
       end

--- a/spec/reverse_proxy/request_spec.rb
+++ b/spec/reverse_proxy/request_spec.rb
@@ -80,7 +80,7 @@ describe Ronin::Web::Server::ReverseProxy::Request do
 
   describe "#request_method=" do
     let(:request_method)     { 'GET' }
-    let(:new_request_method) { 'POST'}
+    let(:new_request_method) { 'POST' }
     let(:env) do
       {'REQUEST_METHOD' => request_method}
     end
@@ -94,7 +94,7 @@ describe Ronin::Web::Server::ReverseProxy::Request do
 
   describe "#query_string=" do
     let(:query_string)     { 'GET' }
-    let(:new_query_string) { 'POST'}
+    let(:new_query_string) { 'POST' }
     let(:env) do
       {'QUERY_STRING' => query_string}
     end


### PR DESCRIPTION
I have taken the [command_kit `.rubocop.yml`](https://github.com/postmodern/command_kit.rb/blob/main/.rubocop.yml), but there are new cops that have been added over the time, and I was not sure what you would prefer, so here's the set of new violation we can fix or disable.

When you have a second, let me know what you prefer, and I'll adjust `.rubocop.yml ` and create a real PR. I can also generate a config with `--auto-gen-config` and open separate PR for each fixes, tho.

* `Gemfile:19:3: C: [Correctable] Bundler/OrderedGems: Gems should be sorted in an alphabetical order within their section of the Gemfile.`
* `Rakefile:8:8: W: [Correctable] Lint/AmbiguousOperator: Ambiguous negative number operator. Parenthesize the method arguments if it's surely a negative number operator, or add a whitespace to the right of the - if it should be a subtraction.`
* `lib/ronin/web/server/base.rb:26:1: W: [Correctable] Lint/RedundantRequireStatement: Remove unnecessary require statement.
require 'thread'`
* `lib/ronin/web/server/base.rb:171:30: W: Lint/ShadowingOuterLocalVariable: Shadowing outer local variable - handler. runner = lambda { |handler,server|`
* `lib/ronin/web/server/base.rb:171:30: W: Lint/ShadowingOuterLocalVariable: Shadowing outer local variable - handler. runner = lambda { |handler,server|`
* `lib/ronin/web/server/base.rb:173:62: W: Lint/ShadowingOuterLocalVariable: Shadowing outer local variable - server. handler.run(server,Host: bind, Port: port) do |server|`
* `lib/ronin/web/server/base.rb:173:62: W: Lint/ShadowingOuterLocalVariable: Shadowing outer local variable -  handler.run(server,Host: bind, Port: port) do |server|`
* `lib/ronin/web/server/base.rb:179:41: W: Lint/UselessAssignment: Useless assignment to variable - e. rescue Errno::EADDRINUSE => e`
* `lib/ronin/web/server/base.rb:180:15: C: [Correctable] Style/StderrPuts: Use warn instead of $stderr.puts to allow such output to be disabled.`                                     
* `lib/ronin/web/server/conditions.rb:68:33: C: Style/CaseEquality: Avoid the use of the case equality operator ===.`
* `lib/ronin/web/server/conditions.rb:383:21: W: Lint/UselessAssignment: Useless assignment to variable - os.` <= this one seems to be an error
* `lib/ronin/web/server/request.rb:62:13: C: [Correctable] Style/Next: Use next to skip iteration.`
* `lib/ronin/web/server/reverse_proxy.rb:153:76: C: [Correctable] Style/HashSyntax: Omit the hash value.`
* `lib/ronin/web/server/reverse_proxy/request.rb:96:13: W: Lint/ReturnInVoidContext: Do not return a value in ssl=.`
* `lib/ronin/web/server/routing.rb:67:38: C: [Correctable] Naming/BlockForwarding: Use anonymous block forwarding.`
* `ronin-web-server.gemspec:1:1: C: [Correctable] Style/Encoding: Unnecessary utf-8 encoding comment.`
* `ronin-web-server.gemspec:35:3: C: [Correctable] Gemspec/DeprecatedAttributeAssignment: Do not set test_files in gemspec.`
* `spec/request_spec.rb:33:44: C: [Correctable] Style/RedundantInterpolation: Prefer to_s over string interpolation.`
